### PR TITLE
feat: 完善冒号删除功能，删除中文冒号、“秒”字，如果没有空格则补上空格

### DIFF
--- a/components/Sentence.tsx
+++ b/components/Sentence.tsx
@@ -9,7 +9,7 @@ export default function Sentence({
 }) {
   const baseUrl = `https://www.bilibili.com/video/${bvId}`;
 
-  const matchResult = sentence.match(/\s*(\d+\.\d+)(.*)/);
+  const matchResult = sentence.match(/\s*(\d+[\.:]\d+)(.*)/);
   if (matchResult) {
     const seconds = matchResult[1];
     const { formattedContent, timestamp } = extractTimestamp(matchResult);

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -90,7 +90,7 @@ export const Home: NextPage = () => {
   const summaryArray = summary.split("- ");
   const formattedSummary = summaryArray
     .map((s) => {
-      const matchResult = s.match(/\s*(\d+\.\d+)(.*)/);
+      const matchResult = s.match(/\s*(\d+[\.:]\d+)(.*)/);
       if (matchResult) {
         const { formattedContent, timestamp } = extractTimestamp(matchResult);
         return timestamp + formattedContent;

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -94,8 +94,9 @@ export const Home: NextPage = () => {
       if (matchResult) {
         const { formattedContent, timestamp } = extractTimestamp(matchResult);
         return timestamp + formattedContent;
+      } else {
+        return s.replace(/\n\n/g, '\n');
       }
-      return s;
     })
     .join("\n- ");
 

--- a/utils/extractTimestamp.ts
+++ b/utils/extractTimestamp.ts
@@ -1,7 +1,6 @@
 export function extractTimestamp(matchResult: RegExpMatchArray) {
-  console.log("========matchResult========", matchResult);
   let timestamp: string | undefined;
-  const seconds = Number(matchResult[1]);
+  const seconds = Number(matchResult[1].replace(':', '.'));
   const hours = Math.floor(seconds / 3600);
   const remainingSeconds = Math.floor(seconds % 3600);
   const minutes = Math.floor(remainingSeconds / 60);
@@ -26,5 +25,6 @@ export function extractTimestamp(matchResult: RegExpMatchArray) {
   }catch(e){
     console.log('handle text after time error', e);
   }
+  console.log("========matchResult========", {matchResult, timestamp, formattedContent});
   return { timestamp, formattedContent };
 }

--- a/utils/extractTimestamp.ts
+++ b/utils/extractTimestamp.ts
@@ -15,8 +15,16 @@ export function extractTimestamp(matchResult: RegExpMatchArray) {
   }
 
   const content = matchResult[2];
-  const formattedContent = content?.startsWith(":")
-    ? content.substring(1)
-    : content;
+  let formattedContent = content;
+  try {
+    formattedContent = (content && /^[:：秒]/.test(content))
+      ? content.substring(1)
+      : content;
+    formattedContent = (formattedContent && !/^ /.test(formattedContent))
+      ? ' ' + formattedContent
+      : formattedContent;
+  }catch(e){
+    console.log('handle text after time error', e);
+  }
   return { timestamp, formattedContent };
 }


### PR DESCRIPTION
1. 对时间戳后面的字符删除，包括：`:` `：` `秒` 共三种；
2. 如果时间戳后面没有空格，会补上一个空格，方便b站识别成蓝色；
3. 有时候gpt回复中会把时间戳的`.`写成':'，导致识别不到，我把它转回点了；
4. 删除多余空行，防止b站自动把多余空行全删光变成没有空行了。目前看，b站空一行还是不会被删的，空两行好像就会被删。